### PR TITLE
Add workaround for hanging UI when scrolling main charts list

### DIFF
--- a/Swift Charts Examples/ContentView.swift
+++ b/Swift Charts Examples/ContentView.swift
@@ -29,6 +29,11 @@ struct ContentView: View {
                     Section {
                         ForEach(ChartType.allCases.filter { $0.category == category }) { chart in
                             NavigationLink(value: chart) {
+                                // causes UI to hang for several seconds when scrolling
+                                // from 100% CPU usage when cells are reloaded
+//                                chart.view
+                                
+                                // workaround to address hanging UI
                                 cachedView(chart: chart)
                             }
                         }

--- a/Swift Charts Examples/ContentView.swift
+++ b/Swift Charts Examples/ContentView.swift
@@ -7,6 +7,21 @@ import SwiftUI
 struct ContentView: View {
     @State private var selectedChartType: ChartType?
     
+    private var cachedChartImages: [String: UIImage] = [:]
+    
+    @MainActor
+    init() {
+        ChartType.allCases.forEach { chart in
+            let view = chart.view
+                .frame(width: 300)
+                .background(.white)
+            let renderer = ImageRenderer(content: view)
+            if let image = renderer.cgImage {
+                cachedChartImages[chart.id] = UIImage(cgImage: image)
+            }
+        }
+    }
+    
     var body: some View {
         NavigationSplitView {
             List(selection: $selectedChartType) {
@@ -14,7 +29,7 @@ struct ContentView: View {
                     Section {
                         ForEach(ChartType.allCases.filter { $0.category == category }) { chart in
                             NavigationLink(value: chart) {
-                                chart.view
+                                cachedView(chart: chart)
                             }
                         }
                     } header: {
@@ -33,6 +48,18 @@ struct ContentView: View {
                 }
             }
         }
+    }
+    
+    private func cachedView(chart: ChartType) -> AnyView {
+        guard let image = cachedChartImages[chart.id] else {
+            return AnyView(Text(chart.title))
+        }
+        return AnyView(
+            Image(uiImage: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: 300)
+        )
     }
 }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/16542463/174160524-870a34d7-7106-4fe2-97dd-07a86aaa25a2.mp4

Seems to work, not an ideal solution but it makes the app performant again.

Also handles splitview menu for iPhone in landscape mode.

![Simulator Screen Shot - iPhone 13 Pro Max - 2022-06-16 at 21 45 46](https://user-images.githubusercontent.com/16542463/174160585-becb2984-a5d3-48de-b851-8c7750dd3918.png)

