### PR TITLE
Render chart preview images at the screen's native scale

### DIFF
--- a/Swift Charts Examples/ContentView.swift
+++ b/Swift Charts Examples/ContentView.swift
@@ -17,6 +17,7 @@ struct ContentView: View {
                 .padding(10)
                 .frame(width: 300)
             let renderer = ImageRenderer(content: view)
+            renderer.scale = UIScreen.main.scale
             if let image = renderer.uiImage {
                 cachedChartImages[chart.id] = image
             }


### PR DESCRIPTION
Thanks for creating this great resource, Jordi. I ran into a small improvement opportunity: the chart previews currently are rendered @1x. This silly one-liner PR renders them at the screen's native scale instead.