### PR TITLE
Add accessibility labels and descriptors for day/week ScreenTime chart

### DIFF
--- a/Swift Charts Examples/Data/ScreenTimeData.swift
+++ b/Swift Charts Examples/Data/ScreenTimeData.swift
@@ -475,7 +475,6 @@ extension Array where Element == ScreenTimeValue {
 			var result = partialResult
 			day.value.forEach({ value in
 				if let index = result.firstIndex(where: { ($0.category == value.category) && (Calendar.current.isDate($0.valueDate, inSameDayAs: day.key)) }) {
-					print("Hey")
 					result[index].duration += value.duration
 				} else {
 					result.append(ScreenTimeValue(valueDate: day.key, category: value.category, duration: value.duration))

--- a/Swift Charts Examples/Model/ChartType.swift
+++ b/Swift Charts Examples/Model/ChartType.swift
@@ -205,8 +205,13 @@ enum ChartType: String, Identifiable, CaseIterable {
             return LinePlot(isOverview: true).makeChartDescriptor()
         case .gitContributions:
             return GitHubContributionsGraph(isOverview: true).makeChartDescriptor()
+        case .screenTime:
+            // This graph mirrors Apple's implementation
+            // each individual sub graph has it's own audio graph/descriptor
+            fallthrough
         default:
             return nil
+
         }
     }
 

--- a/Swift Charts Examples/Utilities/AccessibilityHelpers.swift
+++ b/Swift Charts Examples/Utilities/AccessibilityHelpers.swift
@@ -14,11 +14,21 @@ import SwiftUI
  */
 
 extension TimeInterval {
+    var accessibilityDurationFormatter: DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute, .second]
+        formatter.unitsStyle = .brief
+        formatter.maximumUnitCount = 1
+        
+        return formatter
+    }
+    
     var durationDescription: String {
         let hqualifier = (hours == 1) ? "hour" : "hours"
         let mqualifier = (minutes == 1) ? "minute" : "minutes"
         
-        return String(format:"%d \(hqualifier) %02d \(mqualifier)", hours, minutes)
+        return accessibilityDurationFormatter.string(from: self) ??
+        String(format:"%d \(hqualifier) %02d \(mqualifier)", hours, minutes)
     }
 
     var hours: Int {
@@ -44,8 +54,8 @@ extension Date {
 enum AccessibilityHelpers {
     // TODO: This should be a protocol but since the data objects are in flux this will suffice
     static func chartDescriptor(forSalesSeries data: [Sale],
-                         saleThreshold: Double? = nil,
-                         isContinuous: Bool = false) -> AXChartDescriptor {
+                                saleThreshold: Double? = nil,
+                                isContinuous: Bool = false) -> AXChartDescriptor {
 
         // Since we're measuring a tangible quantity,
         // keeping an independant minimum prevents visual scaling in the Rotor Chart Details View


### PR DESCRIPTION
This PR adds accessibility support for ScreenTime charts. The labels, values and descriptors attempt to mimic Apple's implementation of the same in the Settings.app charts (see captions at bottom of these screens).
 
| ![IMG_2548](https://user-images.githubusercontent.com/5402357/177422356-f4ad234d-1c4d-438d-bbe7-857478d7f52a.PNG) | ![IMG_2547](https://user-images.githubusercontent.com/5402357/177422362-37a99356-0c6f-49e5-8208-2be662d070fa.PNG) |
| --- | --- |


This should complete some base level accessibility for all chart types (Some charts like Area charts only have chart descriptor support).


I'll update issue #24 with potential next steps/tasks that I think can help flesh out accessibility support. 