### PR TITLE
Fix broken previews

### DIFF
--- a/Swift Charts Examples/Charts/BarCharts/PyramidChart.swift
+++ b/Swift Charts Examples/Charts/BarCharts/PyramidChart.swift
@@ -43,17 +43,7 @@ struct PyramidChart: View {
 	private var chart: some View {
 		Chart(data) { series in
 			ForEach(series.population, id: \.percentage) { element in
-                Plot {
-                    BarMark(
-                        xStart: .value("Percentage", 0),
-                        xEnd: .value("Percentage", series.sex == "Male" ? element.percentage : element.percentage * -1),
-                        y: .value("AgeRange", element.ageRange),
-                        height: isOverview ? .automatic : .fixed(barHeight)
-                    )
-                }
-                .accessibilityLabel("\(series.sex); Ages: \(description(for: element.ageRange)) years")
-                .accessibilityValue("\(element.percentage.formatted(.percent))")
-                .accessibilityHidden(isOverview)
+                chartContent(series: series, element: element)
 			}
 			.foregroundStyle(series.sex == "Male" ? rightColor.gradient : leftColor.gradient)
 			.interpolationMethod(.catmullRom)
@@ -79,6 +69,22 @@ struct PyramidChart: View {
 		.chartXAxis(isOverview ? .hidden : .automatic)
 		.frame(height: isOverview ? 200 : 340)
 	}
+
+    // Workaround for previews. Swift compiler seems to have problems checking expression type
+    // for this chart when used directly inside Chart/ForEach, and the preview builds end up timing out.
+    @ChartContentBuilder func chartContent(series: PopulationByAgeData.Series, element: PopulationByAgeData.Series.Population) -> some ChartContent {
+        Plot {
+            BarMark(
+                xStart: .value("Percentage", 0),
+                xEnd: .value("Percentage", series.sex == "Male" ? element.percentage : element.percentage * -1),
+                y: .value("AgeRange", element.ageRange),
+                height: isOverview ? .automatic : .fixed(barHeight)
+            )
+        }
+        .accessibilityLabel("\(series.sex); Ages: \(description(for: element.ageRange)) years")
+        .accessibilityValue("\(element.percentage.formatted(.percent))")
+        .accessibilityHidden(isOverview)
+    }
     
     private var customisation: some View {
         Group {

--- a/Swift Charts Examples/Data/Data.swift
+++ b/Swift Charts Examples/Data/Data.swift
@@ -234,11 +234,13 @@ enum LocationData {
 struct PopulationByAgeData {
     /// A data series for the bars.
     struct Series: Identifiable {
+        typealias Population = (ageRange: String, percentage: Int)
+
         /// Sex.
         let sex: String
 
         /// Percentage population for ageRange
-        let population: [(ageRange: String, percentage: Int)]
+        let population: [Population]
 
         /// The identifier for the series.
         var id: String { sex }


### PR DESCRIPTION
## What

Previews were broken for `ContentView` and `PyramidChart`.
- resolve #86 

## How

- `ContentView` 
    - Runtime crash while previewing
    -  I was able to pinpoint it to image snapshotting code. Moving it to a separate ObservableObject seemed to fix the problem.
- `PyramidChart`
    - Preview build timing out
    - Swift compiler seemed unhappy when checking expression type of content inside `chart` and was timing out (build time more than 30s). Moving it out to a separate function seemed to fix it.
    - Not sure if this is the best way to deal with the problem, but hey, the previews now work 🤷 I'm open to other ideas -- maybe Plot/ForEach order matters? Also, I'm not really sure it's not just a bug that will go away with a future version of Xcode.