### PR TITLE
Fix OneDimentionalBar graph all filled

### DIFF
--- a/Swift Charts Examples/Charts/AppleCharts/OneDimensionalBar.swift
+++ b/Swift Charts Examples/Charts/AppleCharts/OneDimensionalBar.swift
@@ -72,7 +72,7 @@ struct OneDimensionalBar: View {
 		}
         .accessibilityChartDescriptor(self)
         .chartXAxis(.hidden)
-		.chartXScale(range: 0...128)
+		.chartXScale(domain: 0...128)
 		.chartYScale(range: .plotDimension(endPadding: -8))
 		.chartLegend(position: .bottom, spacing: 8)
 		.chartLegend(showLegend ? .visible : .hidden)


### PR DESCRIPTION
I am not familiar with chartXScale's range property, so I can't explain why it is different,
but with range, the graph is not maximized even when the capacity is full, so I changed it to domain.

| domain | range |
| ---|---|
|<img width="500" alt="スクリーンショット" src="https://user-images.githubusercontent.com/33943897/217721119-d268faa9-6c81-460b-a8c1-7a43c37f42c5.png">|<img width="500" alt="スクリーンショット" src="https://user-images.githubusercontent.com/33943897/217721248-38ac16eb-0b5d-491d-8247-ca45c7564c0a.png">|
