### PR TITLE
Fill in Selected Lollipop LineMark in SingleLineLollipop

### DIFF
--- a/Swift Charts Examples/Data/Data.swift
+++ b/Swift Charts Examples/Data/Data.swift
@@ -84,7 +84,7 @@ enum SalesData {
     }
 }
 
-struct Sale {
+struct Sale: Equatable {
     let day: Date
     var sales: Int
 }


### PR DESCRIPTION
Greetings, reviewer!

This PR fills in and slightly expands the currently selected lollipop LineMark. This adds a visual aid for users to more clearly and distinctly see which LineMark they are currently viewing.

### Changes
- `Data.swift`: Made the Sale struct conform to the Equitable protocol. Any data passed to this type of chart should conform to the Equitable protocol in order to easily compare the current selected lollipop LineMark and each LineMark rendered on the Chart.
- `SingleLineLollipop.swift`: Added the lollipop color picker. If the lollipop is currently over the LineMark, it will fill in and slightly expand said LineMark. I wanted to call LineMark's `.symbol` property with a ternary operator - However, there is no mechanism for supplying a `.symbol` with a `ChartSymbolShape` that fills in the shape. This meant that I could not write a ternary operator that chose between the filled in circle (`some View`) and unfilled in circle (`some ChartSymbolShape`) as the types did not match. Hence why I pulled baselineMarker out into its own function first before conditionally deciding which `.symbol` function to call with a parameter type of either `some View` or `some ChartSymbolShape`.

### Before
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-11 at 22 52 42](https://user-images.githubusercontent.com/11247624/218292111-8e33e0fd-1fc5-4bae-9108-9cb14953c77c.png)

### After
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-11 at 22 54 26](https://user-images.githubusercontent.com/11247624/218292141-be391fbd-df59-4383-abdc-3a50743f2c42.png)

Thank you!